### PR TITLE
[FEAT] #22 - 코인 데이터 정렬 기능 추가

### DIFF
--- a/core/data/src/main/java/com/soma/coinviewer/data/network/model/BinanceTickerResponse.kt
+++ b/core/data/src/main/java/com/soma/coinviewer/data/network/model/BinanceTickerResponse.kt
@@ -26,7 +26,7 @@ data class BinanceTickerResponse(
 ) {
     fun toVO() = BinanceTickerData(
         symbol = symbol ?: "",
-        totalTradedQuoteAssetVolume = lastPrice?.toBigDecimalOrNull() ?: BigDecimal(0.0),
+        totalTradedQuoteAssetVolume = totalTradedQuoteAssetVolume?.toBigDecimalOrNull() ?: BigDecimal(0.0),
         price = lastPrice?.toBigDecimalOrNull() ?: BigDecimal(0.0),
         priceChangePercent = priceChangePercent?.toBigDecimalOrNull() ?: BigDecimal(0.0),
         coinIconUrl = "https://raw.githubusercontent.com/spothq/cryptocurrency-icons/master/32/icon/${symbol?.removeSuffix(

--- a/core/data/src/main/java/com/soma/coinviewer/data/repository/BinanceRepositoryImpl.kt
+++ b/core/data/src/main/java/com/soma/coinviewer/data/repository/BinanceRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.soma.coinviewer.data.repository
 import com.soma.coinviewer.data.network.datasource.BinanceDataSource
 import com.soma.coinviewer.domain.model.BinanceTickerData
 import com.soma.coinviewer.domain.model.BinanceTickerData.Companion.BINANCE_TICKER_DATA_MAX_SIZE
+import com.soma.coinviewer.domain.model.BinanceTickerKey
 import com.soma.coinviewer.domain.repository.BinanceRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,15 +22,13 @@ class BinanceRepositoryImpl @Inject constructor(
     override val binanceTickerData: StateFlow<List<BinanceTickerData>> =
         _binanceTickerData.asStateFlow()
 
-    private val binanceTickerDataMap = TreeMap<Pair<BigDecimal, String>, BinanceTickerData>(
-        compareBy<Pair<BigDecimal, String>> { it.first }
-            .thenBy { it.second }
-    )
+    private val binanceTickerDataMap = TreeMap<BinanceTickerKey, BinanceTickerData>()
 
     private val isContainData = HashMap<String, BigDecimal>()
 
     override fun connect() = webSocketDataSource.connect()
     override fun disconnect() = webSocketDataSource.disconnect()
+
     override fun subscribeWebSocketData() {
         scope.launch {
             webSocketDataSource.subscribeWebSocket()
@@ -41,15 +40,19 @@ class BinanceRepositoryImpl @Inject constructor(
 
                         // 기존 Symbol이 존재하는 경우, TreeMap에서 이전 항목 제거
                         isContainData[symbol]?.let { previousVolume ->
-                            binanceTickerDataMap.remove(previousVolume to symbol) // 이전 항목 삭제
+                            val keyToRemove = BinanceTickerKey(previousVolume, symbol)
+                            binanceTickerDataMap.remove(keyToRemove) // 이전 항목 삭제
                         }
 
-                        binanceTickerDataMap[currentVolume to symbol] = data
+                        // 새 데이터를 TreeMap에 추가
+                        val newKey = BinanceTickerKey(currentVolume, symbol)
+                        binanceTickerDataMap[newKey] = data
                         isContainData[symbol] = currentVolume
 
+                        // TreeMap 크기 제한 유지
                         while (binanceTickerDataMap.size > BINANCE_TICKER_DATA_MAX_SIZE) {
                             val lastEntry = binanceTickerDataMap.pollLastEntry()
-                            isContainData.remove(lastEntry?.key?.second)
+                            lastEntry?.key?.symbol?.let { isContainData.remove(it) }
                         }
                     }
 

--- a/core/domain/src/main/java/com/soma/coinviewer/domain/model/BinanceTickerData.kt
+++ b/core/domain/src/main/java/com/soma/coinviewer/domain/model/BinanceTickerData.kt
@@ -13,3 +13,14 @@ data class BinanceTickerData(
         const val BINANCE_TICKER_DATA_MAX_SIZE = 30
     }
 }
+
+data class BinanceTickerKey(
+    val volume: BigDecimal,
+    val symbol: String
+) : Comparable<BinanceTickerKey> {
+    override fun compareTo(other: BinanceTickerKey): Int {
+        return compareBy<BinanceTickerKey> { it.volume }
+            .thenBy { it.symbol }
+            .compare(this, other)
+    }
+}

--- a/feature/home/src/main/java/com/soma/coinviewer/feature/home/HomeFragment.kt
+++ b/feature/home/src/main/java/com/soma/coinviewer/feature/home/HomeFragment.kt
@@ -73,98 +73,39 @@ private fun HomeScreen(
                 .padding(paddingValues),
         ) {
             Row(
-                horizontalArrangement = Arrangement.SpaceEvenly,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(40.dp)
                     .background(Color.LightGray),
             ) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .weight(1f)
-                        .clickable {
-                            updateSortType(ListSortType.SYMBOL_ASC, ListSortType.SYMBOL_DESC)
-                        },
-                ) {
-                    val sortImage = when (listSortType) {
-                        ListSortType.SYMBOL_ASC -> R.drawable.ic_up
-                        ListSortType.SYMBOL_DESC -> R.drawable.ic_down
-                        else -> R.drawable.ic_updown
-                    }
+                HeaderItem(
+                    text = stringResource(R.string.symbol),
+                    listSortType = listSortType,
+                    currentAscType = ListSortType.SYMBOL_ASC,
+                    currentDescType = ListSortType.SYMBOL_DESC,
+                    updateSortType = updateSortType,
+                    modifier = Modifier.weight(1f)
+                )
 
-                    Image(
-                        painter = painterResource(sortImage),
-                        contentDescription = "",
-                    )
+                HeaderItem(
+                    text = stringResource(R.string.price),
+                    listSortType = listSortType,
+                    currentAscType = ListSortType.PRICE_ASC,
+                    currentDescType = ListSortType.PRICE_DESC,
+                    updateSortType = updateSortType,
+                    modifier = Modifier.weight(1f)
+                )
 
-                    Text(
-                        text = stringResource(R.string.symbol),
-                        fontSize = 14.sp,
-                        textAlign = TextAlign.Start,
-                    )
-                }
-
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .weight(1f)
-                        .clickable {
-                            updateSortType(ListSortType.PRICE_ASC, ListSortType.PRICE_DESC)
-                        },
-                ) {
-                    val sortImage = when (listSortType) {
-                        ListSortType.PRICE_ASC -> R.drawable.ic_up
-                        ListSortType.PRICE_DESC -> R.drawable.ic_down
-                        else -> R.drawable.ic_updown
-                    }
-
-                    Image(
-                        painter = painterResource(sortImage),
-                        contentDescription = "",
-                    )
-
-                    Text(
-                        text = stringResource(R.string.price),
-                        fontSize = 14.sp,
-                        textAlign = TextAlign.Start,
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .weight(1f)
-                        .clickable {
-                            updateSortType(
-                                ListSortType.ONE_DAY_CHANGE_ASC,
-                                ListSortType.ONE_DAY_CHANGE_DESC
-                            )
-                        },
-                ) {
-                    val sortImage = when (listSortType) {
-                        ListSortType.ONE_DAY_CHANGE_ASC -> R.drawable.ic_up
-                        ListSortType.ONE_DAY_CHANGE_DESC -> R.drawable.ic_down
-                        else -> R.drawable.ic_updown
-                    }
-
-                    Image(
-                        painter = painterResource(sortImage),
-                        contentDescription = "",
-                    )
-
-                    Text(
-                        text = stringResource(R.string.change_24h),
-                        fontSize = 14.sp,
-                        textAlign = TextAlign.Start,
-                        modifier = Modifier.weight(1f),
-                    )
-                }
+                HeaderItem(
+                    text = stringResource(R.string.change_24h),
+                    listSortType = listSortType,
+                    currentAscType = ListSortType.ONE_DAY_CHANGE_ASC,
+                    currentDescType = ListSortType.ONE_DAY_CHANGE_DESC,
+                    updateSortType = updateSortType,
+                    modifier = Modifier.weight(1f)
+                )
             }
 
             LazyColumn(modifier = Modifier.fillMaxSize()) {
@@ -177,14 +118,45 @@ private fun HomeScreen(
                         navigateToCoinDetail = navigateToCoinDetail,
                     )
 
-                    if (idx != 29) {
+                    if (idx != coinData.lastIndex) {
                         HorizontalDivider(color = Color.DarkGray)
                     }
                 }
             }
-
-
         }
+    }
+}
+
+@Composable
+private fun HeaderItem(
+    text: String,
+    listSortType: ListSortType,
+    currentAscType: ListSortType,
+    currentDescType: ListSortType,
+    updateSortType: (ListSortType, ListSortType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sortImage = when (listSortType) {
+        currentAscType -> R.drawable.ic_up
+        currentDescType -> R.drawable.ic_down
+        else -> R.drawable.ic_updown
+    }
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.clickable { updateSortType(currentAscType, currentDescType) },
+    ) {
+        Image(
+            painter = painterResource(sortImage),
+            contentDescription = "",
+        )
+
+        Text(
+            text = text,
+            fontSize = 14.sp,
+            textAlign = TextAlign.Center,
+        )
     }
 }
 
@@ -198,8 +170,9 @@ private fun CoinItem(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .height(40.dp)
-            .clickable { navigateToCoinDetail(coinData.symbol) },
+            .height(60.dp)
+            .clickable { navigateToCoinDetail(coinData.symbol) }
+            .padding(horizontal = 4.dp),
     ) {
         AsyncImage(
             model = coinData.coinIconUrl,
@@ -207,7 +180,7 @@ private fun CoinItem(
             error = painterResource(com.soma.coinviewer.common_ui.R.drawable.ic_coin_placeholder),
             onError = { Log.w("Img Error", coinData.coinIconUrl) },
             contentDescription = "",
-            modifier = Modifier.size(20.dp),
+            modifier = Modifier.size(40.dp),
         )
 
         Text(


### PR DESCRIPTION
## 연관된 이슈
- closed #22 

## 구현내용
- 웹소켓에서 내려오는 데이터 `Pair<T>`를 **TreeMap의 Key**로 사용하니 가독성이 너무 구려 data class로 래핑

- 홈 화면 코인 데이터 정렬 기능 추가
